### PR TITLE
Add Docker Compose setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite3
+*.egg-info
+dist
+build
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,15 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 
 COPY . /opt/odoo/runbot
+COPY runbot_builder /opt/odoo/runbot_builder
 COPY scripts /opt/odoo/scripts
 
 ENV ADDONS_PATH=/usr/lib/python3/dist-packages/odoo/addons,/opt/odoo/runbot
 
-RUN mkdir -p /var/log/odoo
+RUN mkdir -p /var/log/odoo && \
+    chmod +x /opt/odoo/scripts/*.sh
+
+USER odoo
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["odoo"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM odoo:17
+
+USER root
+
+WORKDIR /opt/odoo
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
+
+COPY . /opt/odoo/runbot
+COPY scripts /opt/odoo/scripts
+
+ENV ADDONS_PATH=/usr/lib/python3/dist-packages/odoo/addons,/opt/odoo/runbot
+
+RUN mkdir -p /var/log/odoo
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["odoo"]

--- a/README.md
+++ b/README.md
@@ -318,8 +318,9 @@ A version or a bundle can be assigned a specific Dockerfile.
 
 ## Docker Compose
 
-For a quick local setup the project can be started using Docker.  After
-building the image, simply run:
+For a quick local setup the project can be started using Docker.  If the
+image is not built yet, run `docker compose build` first and then start
+the services with:
 
 ```bash
 docker compose up

--- a/README.md
+++ b/README.md
@@ -315,3 +315,16 @@ Or by providing a plain Dockerfile in the template.
 Once the Dockerfile is created and the `to_build` field is checked, the Dockerfile will be built (pay attention that no other operations will occur during the build).
 
 A version or a bundle can be assigned a specific Dockerfile.
+
+## Docker Compose
+
+For a quick local setup the project can be started using Docker.  After
+building the image, simply run:
+
+```bash
+docker compose up
+```
+
+This command will start PostgreSQL together with the Runbot, builder and
+leader services.  Once the initialization is complete the Runbot interface
+will be reachable on [http://localhost:8069](http://localhost:8069).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: runbot
+      POSTGRES_USER: odoo
+      POSTGRES_PASSWORD: odoo
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  runbot:
+    build: .
+    command: ["/opt/odoo/scripts/runbot.sh"]
+    depends_on:
+      - db
+    ports:
+      - "8069:8069"
+    environment:
+      DB_HOST: db
+      DB_USER: odoo
+      DB_PASSWORD: odoo
+      DB_NAME: runbot
+      ADDONS_PATH: "/usr/lib/python3/dist-packages/odoo/addons,/opt/odoo/runbot"
+
+  builder:
+    build: .
+    command: ["/opt/odoo/scripts/builder.sh"]
+    depends_on:
+      - db
+    environment:
+      DB_HOST: db
+      DB_USER: odoo
+      DB_PASSWORD: odoo
+      DB_NAME: runbot
+      ADDONS_PATH: "/usr/lib/python3/dist-packages/odoo/addons,/opt/odoo/runbot"
+      FORCED_HOST_NAME: builder
+
+  leader:
+    build: .
+    command: ["/opt/odoo/scripts/leader.sh"]
+    depends_on:
+      - db
+    environment:
+      DB_HOST: db
+      DB_USER: odoo
+      DB_PASSWORD: odoo
+      DB_NAME: runbot
+      ADDONS_PATH: "/usr/lib/python3/dist-packages/odoo/addons,/opt/odoo/runbot"
+      FORCED_HOST_NAME: leader
+
+volumes:
+  pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,19 @@ services:
       POSTGRES_PASSWORD: odoo
     volumes:
       - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "odoo"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
 
   runbot:
     build: .
     command: ["/opt/odoo/scripts/runbot.sh"]
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - "8069:8069"
     environment:
@@ -22,12 +29,14 @@ services:
       DB_PASSWORD: odoo
       DB_NAME: runbot
       ADDONS_PATH: "/usr/lib/python3/dist-packages/odoo/addons,/opt/odoo/runbot"
+    restart: unless-stopped
 
   builder:
     build: .
     command: ["/opt/odoo/scripts/builder.sh"]
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       DB_HOST: db
       DB_USER: odoo
@@ -35,12 +44,14 @@ services:
       DB_NAME: runbot
       ADDONS_PATH: "/usr/lib/python3/dist-packages/odoo/addons,/opt/odoo/runbot"
       FORCED_HOST_NAME: builder
+    restart: unless-stopped
 
   leader:
     build: .
     command: ["/opt/odoo/scripts/leader.sh"]
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       DB_HOST: db
       DB_USER: odoo
@@ -48,6 +59,7 @@ services:
       DB_NAME: runbot
       ADDONS_PATH: "/usr/lib/python3/dist-packages/odoo/addons,/opt/odoo/runbot"
       FORCED_HOST_NAME: leader
+    restart: unless-stopped
 
 volumes:
   pgdata:

--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-exec python3 /opt/odoo/runbot/runbot_builder/builder.py \
+exec python3 /opt/odoo/runbot_builder/builder.py \
     --odoo-path=/usr/lib/python3/dist-packages/odoo \
     --addons-path=${ADDONS_PATH} \
     -d ${DB_NAME:-runbot} \

--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+exec python3 /opt/odoo/runbot_builder/builder.py \
+    --odoo-path=/usr/lib/python3/dist-packages/odoo \
+    --addons-path=${ADDONS_PATH} \
+    -d ${DB_NAME:-runbot} \
+    --db_host=${DB_HOST:-db} \
+    --db_port=${DB_PORT:-5432} \
+    --db_user=${DB_USER:-odoo} \
+    --db_password=${DB_PASSWORD:-odoo} \
+    --forced-host-name=${FORCED_HOST_NAME:-builder}

--- a/scripts/builder.sh
+++ b/scripts/builder.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-exec python3 /opt/odoo/runbot_builder/builder.py \
+exec python3 /opt/odoo/runbot/runbot_builder/builder.py \
     --odoo-path=/usr/lib/python3/dist-packages/odoo \
     --addons-path=${ADDONS_PATH} \
     -d ${DB_NAME:-runbot} \

--- a/scripts/leader.sh
+++ b/scripts/leader.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-exec python3 /opt/odoo/runbot/runbot_builder/leader.py \
+exec python3 /opt/odoo/runbot_builder/leader.py \
     --odoo-path=/usr/lib/python3/dist-packages/odoo \
     --addons-path=${ADDONS_PATH} \
     -d ${DB_NAME:-runbot} \

--- a/scripts/leader.sh
+++ b/scripts/leader.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-exec python3 /opt/odoo/runbot_builder/leader.py \
+exec python3 /opt/odoo/runbot/runbot_builder/leader.py \
     --odoo-path=/usr/lib/python3/dist-packages/odoo \
     --addons-path=${ADDONS_PATH} \
     -d ${DB_NAME:-runbot} \

--- a/scripts/leader.sh
+++ b/scripts/leader.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+exec python3 /opt/odoo/runbot_builder/leader.py \
+    --odoo-path=/usr/lib/python3/dist-packages/odoo \
+    --addons-path=${ADDONS_PATH} \
+    -d ${DB_NAME:-runbot} \
+    --db_host=${DB_HOST:-db} \
+    --db_port=${DB_PORT:-5432} \
+    --db_user=${DB_USER:-odoo} \
+    --db_password=${DB_PASSWORD:-odoo} \
+    --forced-host-name=${FORCED_HOST_NAME:-leader}

--- a/scripts/runbot.sh
+++ b/scripts/runbot.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+exec odoo --workers=2 --without-demo=1 --max-cron-threads=1 \
+    --addons-path=${ADDONS_PATH} \
+    -d ${DB_NAME:-runbot} \
+    --db_host=${DB_HOST:-db} \
+    --db_port=${DB_PORT:-5432} \
+    --db_user=${DB_USER:-odoo} \
+    --db_password=${DB_PASSWORD:-odoo}


### PR DESCRIPTION
## Summary
- add Dockerfile and entrypoint scripts for runbot services
- provide docker-compose configuration
- document Docker Compose usage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6851aabc09ac832fa1be95c2f382cf5a